### PR TITLE
chore: replace org URLs and LICENSE links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 TensoRaws
+Copyright (c) 2024 EutropicAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ccvfi
 
-[![codecov](https://codecov.io/gh/TensoRaws/ccvfi/graph/badge.svg?token=VK0BHDUXAI)](https://codecov.io/gh/TensoRaws/ccvfi)
-[![CI-test](https://github.com/TensoRaws/ccvfi/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/ccvfi/actions/workflows/CI-test.yml)
-[![Release-pypi](https://github.com/TensoRaws/ccvfi/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/ccvfi/actions/workflows/Release.yml)
+[![codecov](https://codecov.io/gh/EutropicAI/ccvfi/graph/badge.svg?token=VK0BHDUXAI)](https://codecov.io/gh/EutropicAI/ccvfi)
+[![CI-test](https://github.com/EutropicAI/ccvfi/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/ccvfi/actions/workflows/CI-test.yml)
+[![Release-pypi](https://github.com/EutropicAI/ccvfi/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/ccvfi/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/ccvfi.svg)](https://badge.fury.io/py/ccvfi)
-![GitHub](https://img.shields.io/github/license/TensoRaws/ccvfi)
+![GitHub](https://img.shields.io/github/license/EutropicAI/ccvfi)
 
 an inference lib for video frame interpolation with VapourSynth support
 
@@ -85,4 +85,4 @@ It still in development, the following models are supported:
 ### License
 
 This project is licensed under the MIT - see
-the [LICENSE file](https://github.com/TensoRaws/ccvfi/blob/main/LICENSE) for details.
+the [LICENSE file](./LICENSE) for details.

--- a/ccvfi/config/drba_config.py
+++ b/ccvfi/config/drba_config.py
@@ -12,7 +12,7 @@ class DRBAConfig(BaseConfig):
 DRBAConfigs = [
     DRBAConfig(
         name=ConfigType.DRBA_IFNet,
-        url="https://github.com/TensoRaws/ccvfi/releases/download/model_zoo/DRBA_IFNet.pkl",
+        url="https://github.com/EutropicAI/ccvfi/releases/download/model_zoo/DRBA_IFNet.pkl",
         hash="4cc518e172156ad6207b9c7a43364f518832d83a4325d484240493a9e2980537",
         in_frame_count=3,
     )

--- a/ccvfi/config/rife_config.py
+++ b/ccvfi/config/rife_config.py
@@ -12,7 +12,7 @@ class RIFEConfig(BaseConfig):
 RIFEConfigs = [
     RIFEConfig(
         name=ConfigType.RIFE_IFNet_v426_heavy,
-        url="https://github.com/TensoRaws/ccvfi/releases/download/model_zoo/RIFE_IFNet_v426_heavy.pkl",
+        url="https://github.com/EutropicAI/ccvfi/releases/download/model_zoo/RIFE_IFNet_v426_heavy.pkl",
         hash="4cc518e172156ad6207b9c7a43364f518832d83a4325d484240493a9e2980537",
         in_frame_count=2,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 description = "an inference lib for video frame interpolation with VapourSynth support"
-homepage = "https://github.com/TensoRaws/ccvfi"
+homepage = "https://github.com/EutropicAI/ccvfi"
 license = "MIT"
 name = "ccvfi"
 readme = "README.md"
-repository = "https://github.com/TensoRaws/ccvfi"
+repository = "https://github.com/EutropicAI/ccvfi"
 version = "0.0.2"
 
 # Requirements


### PR DESCRIPTION
This PR updates explicit org URLs and converts absolute LICENSE links to relative form.

Org URL replacements: 13
LICENSE link conversions (blob): 1
LICENSE link conversions (raw): 0

Old base: TensoRaws
New base: EutropicAI

Relative ./LICENSE links stay correct if branches or hosts change.